### PR TITLE
fix: some spell error when learning cofunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ co {
 #### switch
 
 `switch + case` can choose to execute `co` according to the condition. A case statement contains a conditional expression and a co statement. The following switch statement has two cases:
+
 ```go
 switch { 
     case $(build) == "true" { 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The `<-` operator is used for variable rewriting (usually called assignment in o
 
 ```go
 var a = "foo"
-a <- "bar
+a <- "bar"
 // <- Rewriting the variable, the value of the variable 'a' becomes bar
 ```
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -217,6 +217,7 @@ co {
 #### switch 条件选择
 
 `switch + case` 可以根据条件选择执行 `co`，一个 case 语句包含一个条件表达式和一个 co 语句，如下有两个 case 的 switch 语句：
+
 ```go
 switch { 
 	case $(build) == "true" { 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -113,7 +113,7 @@ var d = $(c) * 2
 
 ```go
 var a = "foo"
-a <- "bar
+a <- "bar"
 // <- 重写变量后，a 变量的值就变成了 bar
 ```
 

--- a/cmd/cofunc/main_list_view.go
+++ b/cmd/cofunc/main_list_view.go
@@ -14,7 +14,7 @@ import (
 )
 
 func startListingView(flows []exported.FlowMetaInsight) (exported.FlowMetaInsight, error) {
-	items := []list.Item{}
+	items := make([]list.Item, 0, len(flows))
 	for _, f := range flows {
 		items = append(items, flowItem(f))
 	}

--- a/functiondriver/driver.go
+++ b/functiondriver/driver.go
@@ -15,7 +15,7 @@ import (
 type Driver interface {
 	// Name returns the name of the driver, e.g. "go", "cmd", etc.
 	Name() string
-	// FunctinName returns the name of the function associated with the driver
+	// FunctionName returns the name of the function associated with the driver
 	FunctionName() string
 	// Manifest returns the manifest of the function associated with the driver
 	Manifest() manifest.Manifest

--- a/parser/block.go
+++ b/parser/block.go
@@ -215,7 +215,7 @@ func (b *Block) GetVarValue(name string) string {
 	return v
 }
 
-// Getvar lookup variable by name in map
+// GetVar lookup variable by name in map
 func (b *Block) getVar(name string) (*_var, *Block) {
 	for p := b; p != nil; p = p.parent {
 		v, ok := p.vtbl.get(name)

--- a/runtime/flow.go
+++ b/runtime/flow.go
@@ -66,7 +66,7 @@ func WithBeforeFunc(_func func(nameid.ID) error) FlowOption {
 	}
 }
 
-// WithAferFunc initializes the after call-back.
+// WithAfterFunc initializes the after call-back.
 func WithAfterFunc(_func func(nameid.ID) error) FlowOption {
 	return func(fb *FlowBody) {
 		fb.afterFunc = _func
@@ -182,7 +182,7 @@ func (f *Flow) ToReady() error {
 }
 
 // ToRunning set the flow to running status and the begin time of the last running
-func (f *Flow) ToRuning() {
+func (f *Flow) ToRunning() {
 	if f.IsRunning() {
 		return
 	}
@@ -239,9 +239,9 @@ type FlowBody struct {
 	// The status of the flow, the value is one of the following:
 	// StatusAdded, StatusReady, StatusRunning, StatusStopped
 	// Added: The flow is added to the flow store, parsed flowl only, not initialized.
-	// Ready: The flow is initialized inlcude node and driver, but not running.
+	// Ready: The flow is initialized include node and driver, but not running.
 	// Running: The flow is running.
-	// Stopped: The flow is stopped, if need to start again, it must be changed to Ready first.
+	// Stopped: The flow is stopped, if you need to start again, it must be changed to Ready first.
 	status StatusType
 
 	// beforeFunc will be invoked beforeFunc the flow is started.
@@ -330,7 +330,7 @@ func (fs *functionStatistics) IsStatus(status StatusType) bool {
 	return fs.status == status
 }
 
-func (fs *functionStatistics) ToRuning() {
+func (fs *functionStatistics) ToRunning() {
 	fs.WithLock(func(body *functionStatisticsBody) {
 		body.begin = time.Now()
 		body.status = StatusRunning
@@ -357,7 +357,7 @@ func (fs *functionStatistics) ToStopped(err error) {
 type progress struct {
 	// Stored seq number of all nodes in a flow
 	nodes []int
-	// Stored seq number of all fnished nodes in a flow
+	// Stored seq number of all finished nodes in a flow
 	done []int
 	// Stored seq number of all running nodes in a flow; The key is the seq number, which is easy to find.
 	running map[int]struct{}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -178,7 +178,7 @@ func (rt *Runtime) HasTrigger(id nameid.ID) (bool, error) {
 }
 
 // StartEventTrigger start the event trigger of a flow, every event trigger function will run in a goroutine
-// When a event triggeer returned without an error, will create and send a event to runtime
+// When a event trigger returned without an error, will create and send a event to runtime
 func (rt *Runtime) StartEventTrigger(ctx context.Context, id nameid.ID) error {
 	flow, err := rt.store.get(id.ID())
 	if err != nil {
@@ -271,7 +271,7 @@ func (rt *Runtime) ExecFlow(ctx context.Context, id nameid.ID) (err0 error) {
 		return fmt.Errorf("not ready: flow %s", id.ID())
 	}
 
-	flow.ToRuning()
+	flow.ToRunning()
 	if err := flow.beforeFunc(id); err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func (rt *Runtime) execStepFunc(ctx context.Context, f *Flow) func([]actuator.No
 
 		// parallel run functions at the step
 		for _, n := range batch {
-			f.GetStatistics(n.(actuator.Task).Seq()).ToRuning()
+			f.GetStatistics(n.(actuator.Task).Seq()).ToRunning()
 			f.Refresh()
 
 			go func(node actuator.Node) {

--- a/service/logset/logset.go
+++ b/service/logset/logset.go
@@ -194,7 +194,7 @@ func newLogFile2Write(path string) (*logFile, error) {
 	}, nil
 }
 
-// newLogFile2Read createa 'Logfile' object, can use it to read the ouput content from the file, the arugment is
+// newLogFile2Read create 'Logfile' object, can use it to read the output content from the file, the argument is
 // file path.
 func newLogFile2Read(path string) (*logFile, error) {
 	f, err := os.OpenFile(path, os.O_RDONLY, 0644)

--- a/service/resource/resource.go
+++ b/service/resource/resource.go
@@ -20,13 +20,13 @@ type Resources struct {
 	HttpTrigger HttpTrigger
 }
 
-// CronTrigger add and remove the cron job by trigger function, the CronTrigger is a resrouce for trigger.
+// CronTrigger add and remove the cron job by trigger function, the CronTrigger is a resource for trigger.
 type CronTrigger interface {
 	Add(format string, ch chan<- time.Time) (interface{}, error)
 	Remove(interface{}) error
 }
 
-// HttpTrigger add and remove the http handler by trigger function, the HttpTrigger is a resrouce for trigger.
+// HttpTrigger add and remove the http handler by trigger function, the HttpTrigger is a resource for trigger.
 type HttpTrigger interface {
 	AddRoute(path string, handler func(w http.ResponseWriter, r *http.Request)) error
 	RemoveRoute(path string) error


### PR DESCRIPTION
Some spell errors when learning cofunc.

Batch check with IDE `Problems`.

Signed-off-by: iutx <root@viper.run>